### PR TITLE
feat: add setTraceId for thread-local 128 bit trace ID

### DIFF
--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -303,6 +303,16 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
     }
 
     /**
+     * Sets the W3C 128 bit trace ID for the current thread. The two arguments
+     * are the high and low 64 bit halves of the trace ID, in that order.
+     * Pass 0, 0 to clear. The trace ID is dumped per sample in JFR alongside
+     * span ID and span name.
+     */
+    public void setTraceId(long hi, long lo) {
+        setTraceId0(hi, lo);
+    }
+
+    /**
      * Clears context identifier for current thread.
      */
     public void clearContextId() {
@@ -320,4 +330,5 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
     private native void filterThread0(Thread thread, boolean enable);
     private native void setContextId0(long contextId);
     private native void setTracingContext0(long spanId, long spanName);
+    private native void setTraceId0(long hi, long lo);
 }

--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -236,6 +236,8 @@ public class JfrReader implements Closeable {
         getVarlong(); // spanId
         getVarlong(); // spanName
         getVarlong(); // contextId
+        getVarlong(); // traceIdHi
+        getVarlong(); // traceIdLo
         int samples = wall ? getVarint() : 1;
         if (wall && hasWallTimeSpan) getVarlong(); // timeSpan is ignored
         return new ExecutionSample(time, tid, stackTraceId, threadState, samples);
@@ -260,6 +262,8 @@ public class JfrReader implements Closeable {
         getVarint(); // spanId
         getVarint(); // spanName
         getVarint(); // contextId
+        getVarint(); // traceIdHi
+        getVarint(); // traceIdLo
         return new AllocationSample(time, tid, stackTraceId, classId, allocationSize, tlabSize);
     }
 
@@ -313,6 +317,8 @@ public class JfrReader implements Closeable {
         getVarint(); // spanId
         getVarint(); // spanName
         getVarint(); // contextId
+        getVarint(); // traceIdHi
+        getVarint(); // traceIdLo
         return new ContendedLock(time, tid, stackTraceId, duration, classId);
     }
 

--- a/src/event.h
+++ b/src/event.h
@@ -62,6 +62,8 @@ class WallClockEvent : public Event {
     u64 _span_id;
     u64 _span_name;
     u64 _context_id;
+    u64 _trace_id_hi;
+    u64 _trace_id_lo;
 };
 
 class AllocEvent : public EventWithClassId {

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1037,6 +1037,8 @@ class Recording {
         buf->putVar64(Profiler::instance()->getSpanId());
         buf->putVar64(Profiler::instance()->getSpanName());
         buf->putVar64(Profiler::instance()->getContextId());
+        buf->putVar64(Profiler::instance()->getTraceIdHi());
+        buf->putVar64(Profiler::instance()->getTraceIdLo());
     }
 
     void writeUserEventTypes(Buffer* buf) {
@@ -1083,6 +1085,8 @@ class Recording {
         buf->putVar64(event->_span_id);
         buf->putVar64(event->_span_name);
         buf->putVar64(event->_context_id);
+        buf->putVar64(event->_trace_id_hi);
+        buf->putVar64(event->_trace_id_lo);
         buf->putVar32(event->_samples);
         buf->putVar64(event->_time_span);
         buf->put8(start, buf->offset() - start);

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -69,6 +69,11 @@ Java_one_profiler_AsyncProfiler_setTracingContext0(JNIEnv* env, jobject unused, 
     Profiler::instance()->setSpanName(spanName);
 }
 
+extern "C" DLLEXPORT void JNICALL
+Java_one_profiler_AsyncProfiler_setTraceId0(JNIEnv* env, jobject unused, jlong hi, jlong lo) {
+    Profiler::instance()->setTraceId((u64) hi, (u64) lo);
+}
+
 extern "C" DLLEXPORT jstring JNICALL
 Java_one_profiler_AsyncProfiler_execute0(JNIEnv* env, jobject unused, jstring command) {
     Arguments args;
@@ -175,6 +180,7 @@ static const JNINativeMethod profiler_natives[] = {
     F(filterThread0,      "(Ljava/lang/Thread;Z)V"),
     F(setContextId0,      "(J)V"),
     F(setTracingContext0, "(JJ)V"),
+    F(setTraceId0,        "(JJ)V"),
 };
 
 static const JNINativeMethod* execute0 = &profiler_natives[2];

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -94,7 +94,9 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
                 << field("spanId", T_LONG, "Span ID")
                 << field("spanName", T_LONG, "SpanName")
-                << field("contextId", T_LONG, "Context ID"))
+                << field("contextId", T_LONG, "Context ID")
+                << field("traceIdHi", T_LONG, "Trace ID High")
+                << field("traceIdLo", T_LONG, "Trace ID Low"))
 
             << (type("jdk.ObjectAllocationInNewTLAB", T_ALLOC_IN_NEW_TLAB, "Allocation in new TLAB")
                 << category("Java Application")
@@ -106,7 +108,9 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("tlabSize", T_LONG, "TLAB Size", F_BYTES)
                 << field("spanId", T_LONG, "Span ID")
                 << field("spanName", T_LONG, "SpanName")
-                << field("contextId", T_LONG, "Context ID"))
+                << field("contextId", T_LONG, "Context ID")
+                << field("traceIdHi", T_LONG, "Trace ID High")
+                << field("traceIdLo", T_LONG, "Trace ID Low"))
 
             << (type("jdk.ObjectAllocationOutsideTLAB", T_ALLOC_OUTSIDE_TLAB, "Allocation outside TLAB")
                 << category("Java Application")
@@ -117,7 +121,9 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("allocationSize", T_LONG, "Allocation Size", F_BYTES)
                 << field("spanId", T_LONG, "Span ID")
                 << field("spanName", T_LONG, "SpanName")
-                << field("contextId", T_LONG, "Context ID"))
+                << field("contextId", T_LONG, "Context ID")
+                << field("traceIdHi", T_LONG, "Trace ID High")
+                << field("traceIdLo", T_LONG, "Trace ID Low"))
 
             << (type("jdk.JavaMonitorEnter", T_MONITOR_ENTER, "Java Monitor Blocked")
                 << category("Java Application")
@@ -130,7 +136,9 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("address", T_LONG, "Monitor Address", F_ADDRESS)
                 << field("spanId", T_LONG, "Span ID")
                 << field("spanName", T_LONG, "SpanName")
-                << field("contextId", T_LONG, "Context ID"))
+                << field("contextId", T_LONG, "Context ID")
+                << field("traceIdHi", T_LONG, "Trace ID High")
+                << field("traceIdLo", T_LONG, "Trace ID Low"))
 
             << (type("jdk.ThreadPark", T_THREAD_PARK, "Java Thread Park")
                 << category("Java Application")
@@ -252,6 +260,8 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("spanId", T_LONG, "Span ID")
                 << field("spanName", T_LONG, "SpanName")
                 << field("contextId", T_LONG, "Context ID")
+                << field("traceIdHi", T_LONG, "Trace ID High")
+                << field("traceIdLo", T_LONG, "Trace ID Low")
                 << field("samples", T_INT, "Samples", F_UNSIGNED)
                 << field("timeSpan", T_LONG, "Time Span", F_DURATION_TICKS))
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -72,11 +72,15 @@ static ProfilingWindow profiling_window;
 static pthread_key_t local_context_id_key;
 static pthread_key_t local_span_id_key;
 static pthread_key_t local_span_name_key;
+static pthread_key_t local_trace_id_hi_key;
+static pthread_key_t local_trace_id_lo_key;
 
 void createContextId() {
     pthread_key_create(&local_context_id_key, NULL);
     pthread_key_create(&local_span_id_key, NULL);
     pthread_key_create(&local_span_name_key, NULL);
+    pthread_key_create(&local_trace_id_hi_key, NULL);
+    pthread_key_create(&local_trace_id_lo_key, NULL);
 }
 
 
@@ -1332,6 +1336,25 @@ Error Profiler::setSpanName(u64 spanName) {
 
 u64 Profiler::getSpanName() {
     void* value = pthread_getspecific(local_span_name_key);
+    return (u64) value;
+}
+
+Error Profiler::setTraceId(u64 hi, u64 lo) {
+    // Write low half first: a sampler that fires between the two writes will
+    // see the previous hi paired with the new lo, which is then filtered out
+    // server-side as a non matching trace_id rather than corrupting state.
+    pthread_setspecific(local_trace_id_lo_key, (void *) lo);
+    pthread_setspecific(local_trace_id_hi_key, (void *) hi);
+    return Error::OK;
+}
+
+u64 Profiler::getTraceIdHi() {
+    void* value = pthread_getspecific(local_trace_id_hi_key);
+    return (u64) value;
+}
+
+u64 Profiler::getTraceIdLo() {
+    void* value = pthread_getspecific(local_trace_id_lo_key);
     return (u64) value;
 }
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -203,6 +203,9 @@ class Profiler {
     u64 getSpanId();
     Error setSpanName(u64 spanName);
     u64 getSpanName();
+    Error setTraceId(u64 hi, u64 lo);
+    u64 getTraceIdHi();
+    u64 getTraceIdLo();
     Error stop(bool restart = false);
     Error flushJfr();
     Error dump(Writer& out, Arguments& args);

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -39,6 +39,8 @@ struct ThreadSleepState {
     u64 span_id;
     u64 span_name;
     u64 context_id;
+    u64 trace_id_hi;
+    u64 trace_id_lo;
 };
 
 typedef std::map<int, ThreadSleepState> ThreadSleepMap;
@@ -49,6 +51,8 @@ struct ThreadCpuTime {
     u64 span_id;
     u64 span_name;
     u64 context_id;
+    u64 trace_id_hi;
+    u64 trace_id_lo;
 };
 
 // MPSC ring buffer
@@ -76,12 +80,14 @@ class ThreadCpuTimeBuffer {
         __atomic_store_n(&_write_ptr, 0, __ATOMIC_RELEASE);
     }
 
-    void add(u64 trace, u64 span_id, u64 span_name, u64 context_id) {
+    void add(u64 trace, u64 span_id, u64 span_name, u64 context_id, u64 trace_id_hi, u64 trace_id_lo) {
         ThreadCpuTime& t = _ringbuf[atomicInc(_write_ptr) & (RINGBUF_SIZE - 1)];
         t.trace = trace;
         t.span_id = span_id;
         t.span_name = span_name;
         t.context_id = context_id;
+        t.trace_id_hi = trace_id_hi;
+        t.trace_id_lo = trace_id_lo;
         storeRelease(t.cpu_time, OS::threadCpuTime(0));
     }
 
@@ -103,6 +109,8 @@ class ThreadCpuTimeBuffer {
                 tss.span_id = t.span_id;
                 tss.span_name = t.span_name;
                 tss.context_id = t.context_id;
+                tss.trace_id_hi = t.trace_id_hi;
+                tss.trace_id_lo = t.trace_id_lo;
                 tss.counter = 0;
                 _read_ptr++;
             }
@@ -148,9 +156,12 @@ void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
         event._span_id = Profiler::instance()->getSpanId();
         event._span_name = Profiler::instance()->getSpanName();
         event._context_id = Profiler::instance()->getContextId();
+        event._trace_id_hi = Profiler::instance()->getTraceIdHi();
+        event._trace_id_lo = Profiler::instance()->getTraceIdLo();
         u64 trace = Profiler::instance()->recordSample(ucontext, _interval, WALL_CLOCK_SAMPLE, &event);
         if (event._thread_state == THREAD_SLEEPING && trace != 0) {
-            _thread_cpu_time_buf.add(trace, event._span_id, event._span_name, event._context_id);
+            _thread_cpu_time_buf.add(trace, event._span_id, event._span_name, event._context_id,
+                                     event._trace_id_hi, event._trace_id_lo);
         }
     } else {
         ExecutionEvent event(TSC::ticks());
@@ -168,6 +179,8 @@ void WallClock::recordWallClock(const ThreadSleepState& tss, ThreadState state, 
     event._span_id = tss.span_id;
     event._span_name = tss.span_name;
     event._context_id = tss.context_id;
+    event._trace_id_hi = tss.trace_id_hi;
+    event._trace_id_lo = tss.trace_id_lo;
     Profiler::instance()->recordExternalSamples(tss.counter, tss.counter * _interval, tid, tss.call_trace_id, WALL_CLOCK_SAMPLE, &event);
 }
 


### PR DESCRIPTION
## Summary

Adds a thread local 128 bit trace ID alongside the existing span ID and span name, exposed via a new `AsyncProfiler.setTraceId(long hi, long lo)` Java method and `Java_one_profiler_AsyncProfiler_setTraceId0` JNI binding. Captured per sample on the WallClockEvent struct and via `writePyroscopeContext` for the other event types. JFR schema and writer extended with `traceIdHi` / `traceIdLo` fields on every event type that already declares `spanId`. Bundled JFR converter (`JfrReader.java`) updated to consume the new fields.

Enables pyroscope-java to carry the W3C trace ID end to end without going through the labels infrastructure (`ScopedContext`), addressing the review on https://github.com/grafana/pyroscope-java/pull/313.